### PR TITLE
fix: reset lastIndex when pattern used the "g" flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ module.exports = function(options) {
 function toPathMatch(pattern) {
   if (typeof pattern === 'string') {
     const reg = pathToRegexp(pattern, [], { end: false });
-    return ctx => reg.test(ctx.path);
+    return ctx => !!ctx.path.match(reg);
   }
-  if (pattern instanceof RegExp) return ctx => pattern.test(ctx.path);
+  if (pattern instanceof RegExp) return ctx => !!ctx.path.match(pattern);
   if (typeof pattern === 'function') return pattern;
   if (Array.isArray(pattern)) {
     const matchs = pattern.map(item => toPathMatch(item));

--- a/index.js
+++ b/index.js
@@ -18,9 +18,15 @@ module.exports = function(options) {
 function toPathMatch(pattern) {
   if (typeof pattern === 'string') {
     const reg = pathToRegexp(pattern, [], { end: false });
-    return ctx => !!ctx.path.match(reg);
+    if (reg.global) reg.lastIndex = 0;
+    return ctx => reg.test(ctx.path);
   }
-  if (pattern instanceof RegExp) return ctx => !!ctx.path.match(pattern);
+  if (pattern instanceof RegExp) {
+    return ctx => {
+      if (pattern.global) pattern.lastIndex = 0;
+      return pattern.test(ctx.path);
+    };
+  }
   if (typeof pattern === 'function') return pattern;
   if (Array.isArray(pattern)) {
     const matchs = pattern.map(item => toPathMatch(item));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-path-matching",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "match or ignore url path",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "egg-path-matching",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "match or ignore url path",
   "main": "index.js",
   "scripts": {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -38,6 +38,16 @@ describe('egg-path-matching', () => {
       assert(fn({ path: '/v1/api1' }) === false);
     });
 
+    it('support global regexp', () => {
+      const fn = match({ match: /^\/api/g });
+      assert(fn({ path: '/api/hello' }) === true);
+      assert(fn({ path: '/api/' }) === true);
+      assert(fn({ path: '/api' }) === true);
+      assert(fn({ path: '/api1/hello' }) === true);
+      assert(fn({ path: '/api1' }) === true);
+      assert(fn({ path: '/v1/api1' }) === false);
+    });
+
     it('support function', () => {
       const fn = match({
         match: ctx => ctx.path.startsWith('/api'),
@@ -77,6 +87,16 @@ describe('egg-path-matching', () => {
 
     it('support regexp', () => {
       const fn = match({ ignore: /^\/api/ });
+      assert(fn({ path: '/api/hello' }) === false);
+      assert(fn({ path: '/api/' }) === false);
+      assert(fn({ path: '/api' }) === false);
+      assert(fn({ path: '/api1/hello' }) === false);
+      assert(fn({ path: '/api1' }) === false);
+      assert(fn({ path: '/v1/api1' }) === true);
+    });
+
+    it('support global regexp', () => {
+      const fn = match({ ignore: /^\/api/g });
       assert(fn({ path: '/api/hello' }) === false);
       assert(fn({ path: '/api/' }) === false);
       assert(fn({ path: '/api' }) === false);


### PR DESCRIPTION
There is an unusual case, but I believe it's a common problems that many people have met.

When I set the middlewares' match rule to regex with 'g' flag as follow:

```
// config.default.js

exports.rest = {
  match /^\/api/g
};
```

Then, some unexpected behaviors appeares:
Sometimes, my requests to the target path has pass through the middleware, but sometimes not.

The cause of the issue is all requests refer to the same global regex instance, so it shares an global state between every request, (not what we want in the case), to resolve this case, just reset the `lastIndex` prop before every request.

Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/lastIndex