### PR TITLE
feat: use path-to-regexp@6.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ and if neither `ignore` nor `match` presented, the new function will always retu
 
 ## Contributors
 
-[![Contributors](https://contrib.rocks/image?repo=node-modules/urllib)](https://github.com/node-modules/urllib/graphs/contributors)
+[![Contributors](https://contrib.rocks/image?repo=eggjs/egg-path-matching)](https://github.com/eggjs/egg-path-matching/graphs/contributors)
 
 Made with [contributors-img](https://contrib.rocks).

--- a/README.md
+++ b/README.md
@@ -54,14 +54,8 @@ and if neither `ignore` nor `match` presented, the new function will always retu
 
 [MIT](LICENSE)
 
-<!-- GITCONTRIBUTOR_START -->
-
 ## Contributors
 
-|[<img src="https://avatars.githubusercontent.com/u/985607?v=4" width="100px;"/><br/><sub><b>dead-horse</b></sub>](https://github.com/dead-horse)<br/>|[<img src="https://avatars.githubusercontent.com/u/156269?v=4" width="100px;"/><br/><sub><b>fengmk2</b></sub>](https://github.com/fengmk2)<br/>|[<img src="https://avatars.githubusercontent.com/u/7903541?v=4" width="100px;"/><br/><sub><b>releasethecow</b></sub>](https://github.com/releasethecow)<br/>|[<img src="https://avatars.githubusercontent.com/u/227713?v=4" width="100px;"/><br/><sub><b>atian25</b></sub>](https://github.com/atian25)<br/>|[<img src="https://avatars.githubusercontent.com/u/5102113?v=4" width="100px;"/><br/><sub><b>xyeric</b></sub>](https://github.com/xyeric)<br/>|
-| :---: | :---: | :---: | :---: | :---: |
+[![Contributors](https://contrib.rocks/image?repo=node-modules/urllib)](https://github.com/node-modules/urllib/graphs/contributors)
 
-
-This project follows the git-contributor [spec](https://github.com/xudafeng/git-contributor), auto updated at `Thu Dec 14 2023 17:20:14 GMT+0800`.
-
-<!-- GITCONTRIBUTOR_END -->
+Made with [contributors-img](https://contrib.rocks).

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "path-to-regexp": "^6.2.2"
+    "path-to-regexp": "^6.3.0"
   },
   "devDependencies": {
     "@eggjs/tsconfig": "1",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "test": "npm run lint -- --fix && npm run test-local",
     "test-local": "egg-bin test",
     "ci": "npm run lint && egg-bin cov && npm run prepublishOnly",
-    "contributor": "git-contributor",
     "prepublishOnly": "tshy && tshy-after"
   },
   "keywords": [
@@ -38,7 +37,6 @@
     "egg-bin": "6",
     "eslint": "8",
     "eslint-config-egg": "13",
-    "git-contributor": "2",
     "tshy": "1",
     "tshy-after": "1",
     "typescript": "5"


### PR DESCRIPTION
https://github.com/eggjs/egg-path-matching/pull/9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the `path-to-regexp` library to the latest version for potential bug fixes and performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->